### PR TITLE
#14 [FEAT] GAME-STORY-003: Flag and unflag suspected mines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV PYTHONPATH=/app
 COPY pyproject.toml .
 RUN pip install --no-cache-dir pytest
 
+COPY Dockerfile .
 COPY minesweeper/ minesweeper/
 COPY tests/ tests/
 

--- a/minesweeper/board.py
+++ b/minesweeper/board.py
@@ -66,3 +66,8 @@ class Board:
                     if 0 <= r < self.rows and 0 <= c < self.cols:
                         self.reveal(r, c)
         return RevealResult.OK
+
+    def toggle_flag(self, row: int, col: int) -> None:
+        cell = self.cell(row, col)
+        if not cell.revealed:
+            cell.flagged = not cell.flagged

--- a/minesweeper/cli.py
+++ b/minesweeper/cli.py
@@ -1,0 +1,25 @@
+import argparse
+
+from minesweeper.board import Board
+from minesweeper.renderer import BoardRenderer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--rows", type=int, default=5)
+    parser.add_argument("--cols", type=int, default=5)
+    parser.add_argument("--mines", type=int, default=3)
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        import random
+
+        random.seed(args.seed)
+
+    board = Board(rows=args.rows, cols=args.cols, mines=args.mines)
+    print(BoardRenderer.render(board))
+
+
+if __name__ == "__main__":
+    main()

--- a/minesweeper/cli.py
+++ b/minesweeper/cli.py
@@ -1,6 +1,7 @@
 import argparse
 
 from minesweeper.board import Board
+from minesweeper.game import Game
 from minesweeper.renderer import BoardRenderer
 
 
@@ -18,7 +19,33 @@ def main():
         random.seed(args.seed)
 
     board = Board(rows=args.rows, cols=args.cols, mines=args.mines)
-    print(BoardRenderer.render(board))
+    game = Game(board)
+    print(BoardRenderer.render(board), end="")
+
+    while True:
+        try:
+            line = input()
+        except EOFError:
+            break
+        parts = line.strip().split()
+        if not parts:
+            continue
+        if parts[0] == "q":
+            break
+        if parts[0] == "f" and len(parts) == 3:
+            try:
+                row, col = int(parts[1]), int(parts[2])
+            except ValueError:
+                continue
+            game.flag(row, col)
+            print(BoardRenderer.render(board), end="")
+        if parts[0] == "r" and len(parts) == 3:
+            try:
+                row, col = int(parts[1]), int(parts[2])
+            except ValueError:
+                continue
+            game.reveal(row, col)
+            print(BoardRenderer.render(board), end="")
 
 
 if __name__ == "__main__":

--- a/minesweeper/game.py
+++ b/minesweeper/game.py
@@ -25,3 +25,7 @@ class Game:
 
     def check_win(self) -> bool:
         return all(c.revealed for c in self.board.grid if not c.is_mine)
+
+    def flag(self, row: int, col: int) -> None:
+        if self.state == GameState.PLAYING:
+            self.board.toggle_flag(row, col)

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -13,3 +13,15 @@ def test_game_be_003_1_s1_toggle_flag_sets_flagged_true_on_unflagged_cell():
 
     # THEN
     assert board.cell(1, 4).flagged is True
+
+
+def test_game_be_003_1_s2_toggle_flag_sets_flagged_false_on_flagged_cell():
+    # GIVEN - cell (1, 4) is already flagged
+    board = Board(rows=3, cols=5, mines=0)
+    board.cell(1, 4).flagged = True
+
+    # WHEN
+    board.toggle_flag(1, 4)
+
+    # THEN
+    assert board.cell(1, 4).flagged is False

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -76,3 +76,19 @@ def test_game_story_003_s2_unflag_flagged_cell_toggle():
     assert board.cell(1, 4).flagged is False
     output = BoardRenderer.render(board)
     assert output.strip().splitlines()[1].split()[4] == "."
+
+
+def test_game_story_003_s3_flag_on_revealed_cell_is_ignored():
+    # GIVEN - cell (2, 2) has already been revealed
+    from minesweeper.game import Game, GameState
+
+    board = Board(rows=3, cols=5, mines=0)
+    game = Game(board)
+    board.cell(2, 2).revealed = True
+
+    # WHEN - the player dispatches flag command f 2 2
+    game.flag(2, 2)
+
+    # THEN - board state is unchanged, no error, game continues
+    assert board.cell(2, 2).flagged is False
+    assert game.state == GameState.PLAYING

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -1,4 +1,6 @@
 # Flag / unflag tests — GAME-BE-003.x scenarios
+from pathlib import Path
+
 from minesweeper.board import Board
 
 
@@ -92,3 +94,30 @@ def test_game_story_003_s3_flag_on_revealed_cell_is_ignored():
     # THEN - board state is unchanged, no error, game continues
     assert board.cell(2, 2).flagged is False
     assert game.state == GameState.PLAYING
+
+
+def test_game_story_003_s4_e2e_flag_cell_and_verify_board_display():
+    # GIVEN - the game is started with --seed 42
+    import os
+    import subprocess
+    import sys
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player enters f 0 0 then q
+    result = subprocess.run(
+        [sys.executable, "minesweeper/cli.py", "--seed", "42"],
+        input="f 0 0\nq\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - stdout contains F at (0,0), process exits with code 0
+    assert result.returncode == 0, f"non-zero exit: {result.stderr}"
+    assert "F" in result.stdout
+    # The second board render (after f 0 0) should show F at position (0, 0)
+    lines = result.stdout.strip().splitlines()
+    # Find the first line that starts with F
+    flag_lines = [ln for ln in lines if ln.split() and ln.split()[0] == "F"]
+    assert flag_lines, "No board line found with F at column 0"

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -25,3 +25,16 @@ def test_game_be_003_1_s2_toggle_flag_sets_flagged_false_on_flagged_cell():
 
     # THEN
     assert board.cell(1, 4).flagged is False
+
+
+def test_game_be_003_2_s1_toggle_flag_on_revealed_cell_is_noop():
+    # GIVEN - cell (2, 2) is already revealed
+    board = Board(rows=3, cols=5, mines=0)
+    board.cell(2, 2).revealed = True
+    board.cell(2, 2).flagged = False
+
+    # WHEN
+    board.toggle_flag(2, 2)
+
+    # THEN - flagged state is unchanged and no exception raised
+    assert board.cell(2, 2).flagged is False

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -57,3 +57,22 @@ def test_game_story_003_s1_flag_unrevealed_cell():
     assert board.cell(1, 4).flagged is True
     output = BoardRenderer.render(board)
     assert output.strip().splitlines()[1].split()[4] == "F"
+
+
+def test_game_story_003_s2_unflag_flagged_cell_toggle():
+    # GIVEN - cell (1, 4) is already flagged
+    from minesweeper.game import Game
+    from minesweeper.renderer import BoardRenderer
+
+    board = Board(rows=3, cols=5, mines=0)
+    game = Game(board)
+    game.flag(1, 4)
+    assert board.cell(1, 4).flagged is True
+
+    # WHEN - the player dispatches flag command f 1 4 again
+    game.flag(1, 4)
+
+    # THEN - cell is unflagged and board renders hidden marker at (1, 4)
+    assert board.cell(1, 4).flagged is False
+    output = BoardRenderer.render(board)
+    assert output.strip().splitlines()[1].split()[4] == "."

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -38,3 +38,22 @@ def test_game_be_003_2_s1_toggle_flag_on_revealed_cell_is_noop():
 
     # THEN - flagged state is unchanged and no exception raised
     assert board.cell(2, 2).flagged is False
+
+
+def test_game_story_003_s1_flag_unrevealed_cell():
+    # GIVEN - cell (1, 4) is unrevealed and not flagged
+    from minesweeper.game import Game
+    from minesweeper.renderer import BoardRenderer
+
+    board = Board(rows=3, cols=5, mines=0)
+    game = Game(board)
+    assert board.cell(1, 4).flagged is False
+    assert board.cell(1, 4).revealed is False
+
+    # WHEN - the player dispatches flag command f 1 4
+    game.flag(1, 4)
+
+    # THEN - cell is flagged and board renders flag marker at (1, 4)
+    assert board.cell(1, 4).flagged is True
+    output = BoardRenderer.render(board)
+    assert output.strip().splitlines()[1].split()[4] == "F"

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -1,1 +1,15 @@
-# Flag / unflag tests — GAME-BE-003.x scenarios will be added here
+# Flag / unflag tests — GAME-BE-003.x scenarios
+from minesweeper.board import Board
+
+
+def test_game_be_003_1_s1_toggle_flag_sets_flagged_true_on_unflagged_cell():
+    # GIVEN - cell (1, 4) is unrevealed and not flagged
+    board = Board(rows=3, cols=5, mines=0)
+    assert board.cell(1, 4).flagged is False
+    assert board.cell(1, 4).revealed is False
+
+    # WHEN
+    board.toggle_flag(1, 4)
+
+    # THEN
+    assert board.cell(1, 4).flagged is True

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -1,0 +1,1 @@
+# Flag / unflag tests — GAME-BE-003.x scenarios will be added here

--- a/tests/test_infra_game_003.py
+++ b/tests/test_infra_game_003.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).parent.parent / "Dockerfile"
+
+
+def test_game_infra_003_1_s1_dockerfile_declares_buildable_image():
+    # GIVEN - a Dockerfile exists at the project root
+    assert DOCKERFILE.exists(), "Dockerfile not found"
+
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - it declares a valid buildable image
+    assert "FROM python" in content
+    assert "WORKDIR /app" in content
+    assert "PYTHONPATH=/app" in content
+    assert "COPY minesweeper/" in content
+    assert "COPY tests/" in content
+    assert "pytest" in content

--- a/tests/test_infra_game_003.py
+++ b/tests/test_infra_game_003.py
@@ -48,3 +48,17 @@ def test_game_infra_003_2_s1_dockerfile_installs_pytest():
     # WHEN / THEN - pytest is installed via pip inside the container
     assert "pip install" in content
     assert "pytest" in content
+
+
+def test_game_infra_003_4_s2_repository_supports_pytest_discovery_inside_docker():
+    # GIVEN - the repository root and tests/ directory
+    tests_dir = Path(__file__).parent
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - structure required for pytest discovery inside Docker is present
+    assert tests_dir.exists()
+    assert (tests_dir / "test_infra_game_003.py").exists()
+    assert (tests_dir / "test_flag.py").exists()
+    assert "COPY tests/" in content
+    assert "pytest" in content
+    assert "tests/" in content

--- a/tests/test_infra_game_003.py
+++ b/tests/test_infra_game_003.py
@@ -18,6 +18,20 @@ def test_game_infra_003_1_s1_dockerfile_declares_buildable_image():
     assert "pytest" in content
 
 
+def test_game_infra_003_3_s1_cli_module_is_importable():
+    # GIVEN - the project is installed inside the container
+
+    # WHEN / THEN - cli.py exists and imports without errors
+    cli_path = Path(__file__).parent.parent / "minesweeper" / "cli.py"
+    assert cli_path.exists(), "minesweeper/cli.py not found"
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("minesweeper.cli", cli_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # raises on ImportError
+
+
 def test_game_infra_003_2_s1_dockerfile_installs_pytest():
     # GIVEN - the Docker image has been built successfully
 

--- a/tests/test_infra_game_003.py
+++ b/tests/test_infra_game_003.py
@@ -32,6 +32,14 @@ def test_game_infra_003_3_s1_cli_module_is_importable():
     spec.loader.exec_module(module)  # raises on ImportError
 
 
+def test_game_infra_003_4_s1_flag_test_module_is_discoverable():
+    # GIVEN - the tests/ directory exists in the project
+
+    # WHEN / THEN - a flag-related test file exists for pytest to discover
+    flag_test = Path(__file__).parent / "test_flag.py"
+    assert flag_test.exists(), "tests/test_flag.py not found"
+
+
 def test_game_infra_003_2_s1_dockerfile_installs_pytest():
     # GIVEN - the Docker image has been built successfully
 

--- a/tests/test_infra_game_003.py
+++ b/tests/test_infra_game_003.py
@@ -16,3 +16,13 @@ def test_game_infra_003_1_s1_dockerfile_declares_buildable_image():
     assert "COPY minesweeper/" in content
     assert "COPY tests/" in content
     assert "pytest" in content
+
+
+def test_game_infra_003_2_s1_dockerfile_installs_pytest():
+    # GIVEN - the Docker image has been built successfully
+
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - pytest is installed via pip inside the container
+    assert "pip install" in content
+    assert "pytest" in content

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -32,3 +32,17 @@ def test_game_fe_003_1_s1_flagged_cell_renders_with_flag_marker():
     assert all(s == "." for s in rows[0].split())
     assert rows[1].split()[:4] == [".", ".", ".", "."]
     assert all(s == "." for s in rows[2].split())
+
+
+def test_game_fe_003_1_s2_unflagged_cell_reverts_to_hidden_marker():
+    # GIVEN - cell (1, 4) was flagged and has just been unflagged
+    board = Board(rows=3, cols=5, mines=0)
+    board.cell(1, 4).flagged = True
+    board.toggle_flag(1, 4)
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - position (1, 4) displays the hidden symbol again
+    rows = output.strip().splitlines()
+    assert rows[1].split()[4] == "."

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -16,3 +16,19 @@ def test_board_fe_001_1_s1_initial_board_renders_all_cells_as_hidden():
         symbols = row.split()
         assert len(symbols) == 2
         assert all(s == "." for s in symbols)
+
+
+def test_game_fe_003_1_s1_flagged_cell_renders_with_flag_marker():
+    # GIVEN - cell (1, 4) is flagged
+    board = Board(rows=3, cols=5, mines=0)
+    board.cell(1, 4).flagged = True
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - position (1, 4) displays "F"; all other cells show hidden symbol
+    rows = output.strip().splitlines()
+    assert rows[1].split()[4] == "F"
+    assert all(s == "." for s in rows[0].split())
+    assert rows[1].split()[:4] == [".", ".", ".", "."]
+    assert all(s == "." for s in rows[2].split())


### PR DESCRIPTION
Closes #14

## Changes
- Added GAME-STORY-003 INFRA coverage for Docker buildability, pytest installation, CLI importability, and pytest discovery.
- Added Board.toggle_flag behavior for flag, unflag, and revealed-cell no-op.
- Added Game.flag flow for player flag actions.
- Added renderer coverage for flagged and unflagged cell display.
- Added CLI E2E flow for flagging a cell and verifying board output.

## Testing
- [x] python3 -m pytest -v
- [x] docker build -t minesweeper .
- [x] docker run --rm minesweeper