### PR TITLE
#18 [FEAT] CLI-STORY-002: Render board state after each action

### DIFF
--- a/tests/test_infra_cli_002.py
+++ b/tests/test_infra_cli_002.py
@@ -40,3 +40,15 @@ def test_cli_infra_002_3_s1_cli_module_is_importable():
     spec = importlib.util.spec_from_file_location("minesweeper.cli", cli_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+
+
+def test_cli_infra_002_4_s1_rendering_tests_are_discoverable():
+    # GIVEN - the repository root and tests/ directory
+    tests_dir = Path(__file__).parent
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - structure required for rendering test discovery inside Docker
+    assert (tests_dir / "test_renderer.py").exists()
+    assert "COPY tests/" in content
+    assert "pytest" in content
+    assert "tests/" in content

--- a/tests/test_infra_cli_002.py
+++ b/tests/test_infra_cli_002.py
@@ -26,3 +26,17 @@ def test_cli_infra_002_2_s1_dockerfile_installs_pytest():
     # WHEN / THEN - pytest is installed via pip inside the container
     assert "pip install" in content
     assert "pytest" in content
+
+
+def test_cli_infra_002_3_s1_cli_module_is_importable():
+    # GIVEN - the project is available inside the container
+
+    cli_path = Path(__file__).parent.parent / "minesweeper" / "cli.py"
+    assert cli_path.exists(), "minesweeper/cli.py not found"
+
+    import importlib.util
+
+    # WHEN / THEN - cli.py loads without ImportError
+    spec = importlib.util.spec_from_file_location("minesweeper.cli", cli_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)

--- a/tests/test_infra_cli_002.py
+++ b/tests/test_infra_cli_002.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).parent.parent / "Dockerfile"
+
+
+def test_cli_infra_002_1_s1_dockerfile_declares_buildable_image():
+    # GIVEN - a Dockerfile exists at the project root using a Python base image
+
+    assert DOCKERFILE.exists(), "Dockerfile not found"
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - it declares a valid buildable image
+    assert "FROM python" in content
+    assert "WORKDIR /app" in content
+    assert "PYTHONPATH=/app" in content
+    assert "COPY minesweeper/" in content
+    assert "COPY tests/" in content
+    assert "pytest" in content

--- a/tests/test_infra_cli_002.py
+++ b/tests/test_infra_cli_002.py
@@ -16,3 +16,13 @@ def test_cli_infra_002_1_s1_dockerfile_declares_buildable_image():
     assert "COPY minesweeper/" in content
     assert "COPY tests/" in content
     assert "pytest" in content
+
+
+def test_cli_infra_002_2_s1_dockerfile_installs_pytest():
+    # GIVEN - the Docker image has been built successfully
+
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - pytest is installed via pip inside the container
+    assert "pip install" in content
+    assert "pytest" in content

--- a/tests/test_infra_cli_002.py
+++ b/tests/test_infra_cli_002.py
@@ -52,3 +52,17 @@ def test_cli_infra_002_4_s1_rendering_tests_are_discoverable():
     assert "COPY tests/" in content
     assert "pytest" in content
     assert "tests/" in content
+
+
+def test_cli_infra_002_4_s2_repository_supports_pytest_discovery_inside_docker():
+    # GIVEN - the repository root and tests/ directory
+    tests_dir = Path(__file__).parent
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - structure required for pytest discovery inside Docker is present
+    assert tests_dir.exists()
+    assert (tests_dir / "test_infra_cli_002.py").exists()
+    assert (tests_dir / "test_renderer.py").exists()
+    assert "COPY tests/" in content
+    assert "pytest" in content
+    assert "tests/" in content

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -144,3 +144,19 @@ def test_cli_fe_002_1_s2_board_printed_after_flag_action():
     assert "F" in result.stdout
     lines = result.stdout.splitlines()
     assert any(ln.split() and ln.split()[1] == "F" for ln in lines)
+
+
+def test_cli_story_002_s1_hidden_cells_render_as_hidden_symbol():
+    # GIVEN - a 4x5 board with no cells revealed or flagged
+    board = Board(rows=4, cols=5, mines=0)
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - every cell displays "." and grid matches configured dimensions
+    rows = output.strip().splitlines()
+    assert len(rows) == 4
+    for row in rows:
+        symbols = row.split()
+        assert len(symbols) == 5
+        assert all(s == "." for s in symbols)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -210,3 +210,31 @@ def test_cli_story_002_s4_revealed_empty_cell_displays_blank_marker():
     first_row = output.splitlines()[0]
     # Row format: "sym sym" — first symbol is the empty-cell marker (space)
     assert first_row.startswith(" ")
+
+
+def test_cli_story_002_s5_e2e_board_state_visible_after_each_action():
+    # GIVEN - the game is started with --seed 42
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player enters r 0 0, f 0 1 (if unrevealed), q
+    # Use --mines 0 so (0,0) flood-fills but (0,1) stays unrevealed for flagging
+    # With seed 42 and 3 mines, flag before reveal to ensure (0,1) is unflagged
+    result = subprocess.run(
+        [sys.executable, "minesweeper/cli.py", "--seed", "42"],
+        input="f 0 1\nr 0 0\nq\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - both renders appear, F visible, process exits 0, no traceback
+    assert result.returncode == 0, result.stderr
+    assert "Traceback" not in result.stderr
+    assert "F" in result.stdout
+    # At least 3 board renders: initial + after f + after r = 15 lines minimum
+    assert len(result.stdout.splitlines()) >= 15

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -178,3 +178,20 @@ def test_cli_story_002_s2_revealed_numbered_cell_shows_adjacent_count():
         for c_idx, sym in enumerate(row.split()):
             if (r_idx, c_idx) != (2, 3):
                 assert sym == "."
+
+
+def test_cli_story_002_s3_flagged_cell_displays_flag_marker():
+    # GIVEN - cell (1, 4) is flagged and not revealed
+    board = Board(rows=3, cols=5, mines=0)
+    board.cell(1, 4).flagged = True
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - (1, 4) displays "F"; all other cells display "."
+    rows = output.strip().splitlines()
+    assert rows[1].split()[4] == "F"
+    for r_idx, row in enumerate(rows):
+        for c_idx, sym in enumerate(row.split()):
+            if (r_idx, c_idx) != (1, 4):
+                assert sym == "."

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -60,3 +60,20 @@ def test_cli_be_002_1_s1_renderer_outputs_correct_rows_and_columns():
     assert len(rows) == 3
     for row in rows:
         assert len(row.split()) == 4
+
+
+def test_cli_be_002_1_s2_renderer_uses_distinct_symbols():
+    # GIVEN - (0,0) hidden, (0,1) flagged, (0,2) revealed with adjacent_count==1
+    board = Board(rows=1, cols=3, mines=0)
+    board.cell(0, 1).flagged = True
+    board.cell(0, 2).revealed = True
+    board.cell(0, 2).adjacent_count = 1
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN
+    symbols = output.strip().split()
+    assert symbols[0] == "."
+    assert symbols[1] == "F"
+    assert symbols[2] == "1"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -110,3 +110,37 @@ def test_cli_fe_002_1_s1_board_printed_after_reveal_action():
     assert result.returncode == 0, result.stderr
     # Two renders: initial (3 rows) + after reveal (3 rows) = at least 6 lines
     assert len(result.stdout.splitlines()) >= 6
+
+
+def test_cli_fe_002_1_s2_board_printed_after_flag_action():
+    # GIVEN - the CLI is running
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player enters "f 0 1" then "q"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "3",
+            "--cols",
+            "3",
+            "--mines",
+            "0",
+        ],
+        input="f 0 1\nq\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - updated board printed with F at row 0 col 1, process exits 0
+    assert result.returncode == 0, result.stderr
+    assert "F" in result.stdout
+    lines = result.stdout.splitlines()
+    assert any(ln.split() and ln.split()[1] == "F" for ln in lines)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -46,3 +46,17 @@ def test_game_fe_003_1_s2_unflagged_cell_reverts_to_hidden_marker():
     # THEN - position (1, 4) displays the hidden symbol again
     rows = output.strip().splitlines()
     assert rows[1].split()[4] == "."
+
+
+def test_cli_be_002_1_s1_renderer_outputs_correct_rows_and_columns():
+    # GIVEN - a 3x4 board with all cells hidden
+    board = Board(rows=3, cols=4, mines=0)
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - exactly 3 rows, each with exactly 4 cell symbols
+    rows = output.strip().splitlines()
+    assert len(rows) == 3
+    for row in rows:
+        assert len(row.split()) == 4

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -195,3 +195,18 @@ def test_cli_story_002_s3_flagged_cell_displays_flag_marker():
         for c_idx, sym in enumerate(row.split()):
             if (r_idx, c_idx) != (1, 4):
                 assert sym == "."
+
+
+def test_cli_story_002_s4_revealed_empty_cell_displays_blank_marker():
+    # GIVEN - cell (0, 0) is revealed with adjacent_count == 0
+    board = Board(rows=2, cols=2, mines=0)
+    board.cell(0, 0).revealed = True
+    board.cell(0, 0).adjacent_count = 0
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - (0, 0) displays a blank/space marker (project convention)
+    first_row = output.splitlines()[0]
+    # Row format: "sym sym" — first symbol is the empty-cell marker (space)
+    assert first_row.startswith(" ")

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -160,3 +160,21 @@ def test_cli_story_002_s1_hidden_cells_render_as_hidden_symbol():
         symbols = row.split()
         assert len(symbols) == 5
         assert all(s == "." for s in symbols)
+
+
+def test_cli_story_002_s2_revealed_numbered_cell_shows_adjacent_count():
+    # GIVEN - cell (2, 3) is revealed with adjacent_count == 2
+    board = Board(rows=5, cols=5, mines=0)
+    board.cell(2, 3).revealed = True
+    board.cell(2, 3).adjacent_count = 2
+
+    # WHEN
+    output = BoardRenderer.render(board)
+
+    # THEN - (2, 3) displays "2"; all other cells display "."
+    rows = output.strip().splitlines()
+    assert rows[2].split()[3] == "2"
+    for r_idx, row in enumerate(rows):
+        for c_idx, sym in enumerate(row.split()):
+            if (r_idx, c_idx) != (2, 3):
+                assert sym == "."

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -77,3 +77,36 @@ def test_cli_be_002_1_s2_renderer_uses_distinct_symbols():
     assert symbols[0] == "."
     assert symbols[1] == "F"
     assert symbols[2] == "1"
+
+
+def test_cli_fe_002_1_s1_board_printed_after_reveal_action():
+    # GIVEN - the CLI is running with no mines
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player enters "r 0 0" then "q"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "3",
+            "--cols",
+            "3",
+            "--mines",
+            "0",
+        ],
+        input="r 0 0\nq\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - initial board + updated board both printed before exit
+    assert result.returncode == 0, result.stderr
+    # Two renders: initial (3 rows) + after reveal (3 rows) = at least 6 lines
+    assert len(result.stdout.splitlines()) >= 6


### PR DESCRIPTION
Closes #18

## Changes
- Added CLI-STORY-002 INFRA coverage for Docker buildability, pytest installation, CLI importability, and pytest discovery.
- Added renderer coverage for row/column dimensions and distinct hidden, flagged, numbered, and empty cell symbols.
- Added CLI FE coverage for board output after reveal and flag actions.
- Added E2E coverage for board visibility across reveal and flag command sequence.

## Testing
- [x] python3 -m pytest -v
- [x] docker build -t minesweeper .
- [x] docker run --rm minesweeper