### PR TITLE
#20 [TEST] GAME-STORY-002: Add explicit win/loss detection coverage

### DIFF
--- a/minesweeper/cli.py
+++ b/minesweeper/cli.py
@@ -48,6 +48,12 @@ def main():
                 continue
             game.reveal(row, col)
             print(BoardRenderer.render(board), end="")
+            if game.state.name == "WIN":
+                print("You win!")
+                break
+            if game.state.name == "LOSS":
+                print("BOOM! You hit a mine.")
+                break
         else:
             print("Usage: r <row> <col> | f <row> <col> | q")
 

--- a/tests/test_infra_game_002.py
+++ b/tests/test_infra_game_002.py
@@ -16,3 +16,13 @@ def test_game_infra_002_1_s1_dockerfile_declares_buildable_image():
     assert "COPY minesweeper/" in content
     assert "COPY tests/" in content
     assert "pytest" in content
+
+
+def test_game_infra_002_2_s1_dockerfile_installs_pytest():
+    # GIVEN - the Docker image has been built successfully
+
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - pytest is installed via pip inside the container
+    assert "pip install" in content
+    assert "pytest" in content

--- a/tests/test_infra_game_002.py
+++ b/tests/test_infra_game_002.py
@@ -49,3 +49,17 @@ def test_game_infra_002_4_s1_win_loss_test_module_is_discoverable():
     assert (
         Path(__file__).parent / "test_win_loss.py"
     ).exists(), "tests/test_win_loss.py not found"
+
+
+def test_game_infra_002_4_s2_repository_supports_pytest_discovery_inside_docker():
+    # GIVEN - the repository root and tests/ directory
+    tests_dir = Path(__file__).parent
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - structure required for pytest discovery inside Docker is present
+    assert tests_dir.exists()
+    assert (tests_dir / "test_infra_game_002.py").exists()
+    assert (tests_dir / "test_win_loss.py").exists()
+    assert "COPY tests/" in content
+    assert "pytest" in content
+    assert "tests/" in content

--- a/tests/test_infra_game_002.py
+++ b/tests/test_infra_game_002.py
@@ -40,3 +40,12 @@ def test_game_infra_002_3_s1_cli_module_is_importable():
     spec = importlib.util.spec_from_file_location("minesweeper.cli", cli_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+
+
+def test_game_infra_002_4_s1_win_loss_test_module_is_discoverable():
+    # GIVEN - the tests/ directory exists in the project
+
+    # WHEN / THEN - a win/loss test file exists for pytest to discover
+    assert (
+        Path(__file__).parent / "test_win_loss.py"
+    ).exists(), "tests/test_win_loss.py not found"

--- a/tests/test_infra_game_002.py
+++ b/tests/test_infra_game_002.py
@@ -26,3 +26,17 @@ def test_game_infra_002_2_s1_dockerfile_installs_pytest():
     # WHEN / THEN - pytest is installed via pip inside the container
     assert "pip install" in content
     assert "pytest" in content
+
+
+def test_game_infra_002_3_s1_cli_module_is_importable():
+    # GIVEN - the project is available inside the container
+
+    cli_path = Path(__file__).parent.parent / "minesweeper" / "cli.py"
+    assert cli_path.exists(), "minesweeper/cli.py not found"
+
+    import importlib.util
+
+    # WHEN / THEN - cli.py loads without ImportError
+    spec = importlib.util.spec_from_file_location("minesweeper.cli", cli_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)

--- a/tests/test_infra_game_002.py
+++ b/tests/test_infra_game_002.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).parent.parent / "Dockerfile"
+
+
+def test_game_infra_002_1_s1_dockerfile_declares_buildable_image():
+    # GIVEN - a Dockerfile exists at the project root using a Python base image
+
+    assert DOCKERFILE.exists(), "Dockerfile not found"
+    content = DOCKERFILE.read_text()
+
+    # WHEN / THEN - it declares a valid buildable image
+    assert "FROM python" in content
+    assert "WORKDIR /app" in content
+    assert "PYTHONPATH=/app" in content
+    assert "COPY minesweeper/" in content
+    assert "COPY tests/" in content
+    assert "pytest" in content

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -162,3 +162,38 @@ def test_game_fe_002_1_s2_loss_message_printed_on_mine_reveal():
     # THEN - "BOOM!" message printed and process exits cleanly
     assert result.returncode == 0, result.stderr
     assert "BOOM! You hit a mine." in result.stdout
+
+
+def test_game_story_002_s1_loss_revealing_mine_ends_game_immediately():
+    # GIVEN - board with known mine at (1,0) via seed 0
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player reveals the mine cell
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "2",
+            "--cols",
+            "1",
+            "--mines",
+            "1",
+            "--seed",
+            "0",
+        ],
+        input="r 1 0\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - loss message printed, process exits 0, no further input accepted
+    assert result.returncode == 0, result.stderr
+    assert "BOOM! You hit a mine." in result.stdout
+    assert "You win!" not in result.stdout

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -76,3 +76,23 @@ def test_game_be_002_2_s2_game_enters_win_state_after_check_win_passes():
 
     # THEN - game.state == WIN
     assert game.state == GameState.WIN
+
+
+def test_game_be_002_3_s1_flagged_safe_cell_does_not_satisfy_win_condition():
+    # GIVEN - all safe cells except (2, 2) are revealed;
+    # (2, 2) is flagged but not revealed
+    board = Board(rows=3, cols=3, mines=0)
+    board.cell(0, 0).is_mine = True
+    board.compute_adjacent_counts()
+    game = Game(board)
+    for r in range(3):
+        for c in range(3):
+            if not board.cell(r, c).is_mine and (r, c) != (2, 2):
+                board.cell(r, c).revealed = True
+    board.cell(2, 2).flagged = True
+
+    # WHEN
+    result = game.check_win()
+
+    # THEN - flagged-but-unrevealed cell keeps check_win returning False
+    assert result is False

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -58,3 +58,21 @@ def test_game_be_002_2_s1_game_enters_loss_state_on_mine_hit():
     assert game.state == GameState.LOSS
     game.reveal(0, 0)  # should be rejected
     assert board.cell(0, 0).revealed is False
+
+
+def test_game_be_002_2_s2_game_enters_win_state_after_check_win_passes():
+    # GIVEN - a 2x2 board with 1 mine; reveal all safe cells except the last
+    from minesweeper.game import GameState
+
+    board = Board(rows=2, cols=2, mines=0)
+    board.cell(0, 0).is_mine = True
+    board.compute_adjacent_counts()
+    game = Game(board)
+    game.reveal(0, 1)
+    game.reveal(1, 0)
+
+    # WHEN - the last safe cell is revealed
+    game.reveal(1, 1)
+
+    # THEN - game.state == WIN
+    assert game.state == GameState.WIN

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -1,0 +1,1 @@
+# Win/loss detection tests — GAME-BE-002.x scenarios will be added here

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -1,1 +1,22 @@
-# Win/loss detection tests — GAME-BE-002.x scenarios will be added here
+# Win/loss detection tests — GAME-BE-002.x scenarios
+from minesweeper.board import Board
+from minesweeper.game import Game
+
+
+def test_game_be_002_1_s1_check_win_returns_true_when_all_safe_cells_revealed():
+    # GIVEN - a board with 2 mines and 7 safe cells, all safe cells revealed
+    board = Board(rows=3, cols=3, mines=0)
+    board.cell(0, 0).is_mine = True
+    board.cell(0, 1).is_mine = True
+    board.compute_adjacent_counts()
+    game = Game(board)
+    for r in range(3):
+        for c in range(3):
+            if not board.cell(r, c).is_mine:
+                board.cell(r, c).revealed = True
+
+    # WHEN
+    result = game.check_win()
+
+    # THEN
+    assert result is True

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -96,3 +96,35 @@ def test_game_be_002_3_s1_flagged_safe_cell_does_not_satisfy_win_condition():
 
     # THEN - flagged-but-unrevealed cell keeps check_win returning False
     assert result is False
+
+
+def test_game_fe_002_1_s1_win_message_printed_on_game_completion():
+    # GIVEN - a 1x1 board with no mines (revealing the only cell wins immediately)
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player reveals the only safe cell
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "1",
+            "--cols",
+            "1",
+            "--mines",
+            "0",
+        ],
+        input="r 0 0\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - "You win!" is printed and process exits cleanly
+    assert result.returncode == 0, result.stderr
+    assert "You win!" in result.stdout

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -230,3 +230,20 @@ def test_game_story_002_s2_win_revealing_last_safe_cell_ends_game():
     assert result.returncode == 0, result.stderr
     assert "You win!" in result.stdout
     assert "BOOM!" not in result.stdout
+
+
+def test_game_story_002_s3_game_continues_when_safe_cells_remain():
+    # GIVEN - multiple safe cells still unrevealed
+    from minesweeper.game import GameState
+
+    board = Board(rows=3, cols=3, mines=0)
+    board.cell(0, 0).is_mine = True
+    board.compute_adjacent_counts()
+    game = Game(board)
+
+    # WHEN - the player reveals one safe cell
+    game.reveal(1, 1)
+
+    # THEN - check_win returns False; game.state remains PLAYING
+    assert game.check_win() is False
+    assert game.state == GameState.PLAYING

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -20,3 +20,23 @@ def test_game_be_002_1_s1_check_win_returns_true_when_all_safe_cells_revealed():
 
     # THEN
     assert result is True
+
+
+def test_game_be_002_1_s2_check_win_returns_false_when_safe_cell_unrevealed():
+    # GIVEN - a board with 2 mines and 7 safe cells; 1 safe cell still unrevealed
+    board = Board(rows=3, cols=3, mines=0)
+    board.cell(0, 0).is_mine = True
+    board.cell(0, 1).is_mine = True
+    board.compute_adjacent_counts()
+    game = Game(board)
+    # Reveal all safe cells except (2, 2)
+    for r in range(3):
+        for c in range(3):
+            if not board.cell(r, c).is_mine and (r, c) != (2, 2):
+                board.cell(r, c).revealed = True
+
+    # WHEN
+    result = game.check_win()
+
+    # THEN
+    assert result is False

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -40,3 +40,21 @@ def test_game_be_002_1_s2_check_win_returns_false_when_safe_cell_unrevealed():
 
     # THEN
     assert result is False
+
+
+def test_game_be_002_2_s1_game_enters_loss_state_on_mine_hit():
+    # GIVEN - a board where cell (1, 1) is a mine
+    from minesweeper.game import GameState
+
+    board = Board(rows=3, cols=3, mines=0)
+    board.cell(1, 1).is_mine = True
+    board.compute_adjacent_counts()
+    game = Game(board)
+
+    # WHEN - Game.reveal hits the mine
+    game.reveal(1, 1)
+
+    # THEN - game.state == LOSS; subsequent reveal is a no-op
+    assert game.state == GameState.LOSS
+    game.reveal(0, 0)  # should be rejected
+    assert board.cell(0, 0).revealed is False

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -247,3 +247,36 @@ def test_game_story_002_s3_game_continues_when_safe_cells_remain():
     # THEN - check_win returns False; game.state remains PLAYING
     assert game.check_win() is False
     assert game.state == GameState.PLAYING
+
+
+def test_game_story_002_s4_e2e_full_game_from_start_to_win():
+    # GIVEN - a 1x1 board with no mines started via CLI
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player reveals all safe cells (the single cell)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "1",
+            "--cols",
+            "1",
+            "--mines",
+            "0",
+        ],
+        input="r 0 0\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - "You win!" printed, process exits 0, no traceback
+    assert result.returncode == 0, result.stderr
+    assert "You win!" in result.stdout
+    assert "Traceback" not in result.stderr

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -128,3 +128,37 @@ def test_game_fe_002_1_s1_win_message_printed_on_game_completion():
     # THEN - "You win!" is printed and process exits cleanly
     assert result.returncode == 0, result.stderr
     assert "You win!" in result.stdout
+
+
+def test_game_fe_002_1_s2_loss_message_printed_on_mine_reveal():
+    # GIVEN - a 2x1 board with 1 mine at (0,0); (1,0) is safe
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player reveals the mine cell (seed 0 places mine at (1,0))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "2",
+            "--cols",
+            "1",
+            "--mines",
+            "1",
+            "--seed",
+            "0",
+        ],
+        input="r 1 0\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - "BOOM!" message printed and process exits cleanly
+    assert result.returncode == 0, result.stderr
+    assert "BOOM! You hit a mine." in result.stdout

--- a/tests/test_win_loss.py
+++ b/tests/test_win_loss.py
@@ -197,3 +197,36 @@ def test_game_story_002_s1_loss_revealing_mine_ends_game_immediately():
     assert result.returncode == 0, result.stderr
     assert "BOOM! You hit a mine." in result.stdout
     assert "You win!" not in result.stdout
+
+
+def test_game_story_002_s2_win_revealing_last_safe_cell_ends_game():
+    # GIVEN - a 1x1 board with no mines (single safe cell)
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+
+    # WHEN - the player reveals the only safe cell
+    result = subprocess.run(
+        [
+            sys.executable,
+            "minesweeper/cli.py",
+            "--rows",
+            "1",
+            "--cols",
+            "1",
+            "--mines",
+            "0",
+        ],
+        input="r 0 0\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # THEN - "You win!" printed, process exits 0, no loss message
+    assert result.returncode == 0, result.stderr
+    assert "You win!" in result.stdout
+    assert "BOOM!" not in result.stdout


### PR DESCRIPTION
Closes #20

## Changes
- Added explicit GAME-STORY-002 INFRA coverage for Docker buildability, pytest installation, CLI importability, and pytest discovery.
- Added explicit win/loss BE coverage for check_win, loss state, win state, and flagged-safe-cell behavior.
- Added CLI FE coverage for win and loss messages.
- Added original story coverage for loss, win, continue-playing, and full-game win E2E scenarios.

## Testing
- [x] python3 -m pytest -v
- [x] docker build -t minesweeper .
- [x] docker run --rm minesweeper