### PR TITLE
#29 [DOCS] Reference generated SVG files instead of PlantUML sources in architecture docs

### DIFF
--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -6,19 +6,9 @@ Minesweeper is a self-contained CLI application. It has no external systems, dat
 
 ## 3.2 Context Diagram (C4 Level 1)
 
+![System Context](diagrams/c4-context.svg)
+
 Diagram source: `docs/architecture/diagrams/c4-context.puml`
-
-```plantuml
-@startuml c4-context
-!include c4-lib/C4_Context.puml
-
-Person(player, "Player", "Runs the game via CLI and interacts by typing commands")
-System(minesweeper, "Minesweeper", "CLI-based puzzle game. Manages board state, processes player input, and displays results.")
-
-Rel(player, minesweeper, "Reveal cell / Flag cell / Start game", "stdin/stdout")
-
-@enduml
-```
 
 ## 3.3 External Interfaces
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -2,26 +2,9 @@
 
 ## 5.1 Level 1 — Container Diagram (C4)
 
+![Container Diagram](diagrams/c4-container.svg)
+
 Diagram source: `docs/architecture/diagrams/c4-container.puml`
-
-```plantuml
-@startuml c4-container
-!include c4-lib/C4_Container.puml
-
-Person(player, "Player", "Interacts via terminal")
-
-System_Boundary(minesweeper, "Minesweeper") {
-  Container(cli, "CLI", "Python module", "Reads stdin, renders board to stdout")
-  Container(controller, "Game Controller", "Python module", "Orchestrates game loop and input handling")
-  Container(domain, "Domain", "Python module", "Board state, mine placement, reveal/flag logic")
-}
-
-Rel(player, cli, "Types commands", "stdin/stdout")
-Rel(cli, controller, "Parsed command")
-Rel(controller, domain, "Calls")
-
-@enduml
-```
 
 ### Container Responsibilities
 
@@ -35,38 +18,9 @@ Rel(controller, domain, "Calls")
 
 ## 5.2 Level 2 — Component Diagram (C4)
 
+![Component Diagram](diagrams/c4-component.svg)
+
 Diagram source: `docs/architecture/diagrams/c4-component.puml`
-
-```plantuml
-@startuml c4-component
-!include c4-lib/C4_Component.puml
-
-Container_Boundary(domain, "Domain") {
-  Component(board, "Board", "Class", "Holds cell grid, mine positions, revealed/flagged state")
-  Component(cell, "Cell", "Class", "Represents a single cell: mine, adjacent count, state")
-  Component(mine_placer, "MinePlacer", "Function", "Randomly distributes mines on the board")
-  Component(reveal, "RevealService", "Function", "Reveals a cell; triggers flood-fill for empty cells")
-}
-
-Container_Boundary(ctrl, "Game Controller") {
-  Component(game, "Game", "Class", "Game loop, win/loss detection, delegates to domain")
-}
-
-Container_Boundary(cli_layer, "CLI") {
-  Component(renderer, "BoardRenderer", "Function", "Formats and prints board to stdout")
-  Component(parser, "InputParser", "Function", "Parses raw input string into command + coordinates")
-}
-
-Rel(game, board, "Reads/mutates")
-Rel(game, reveal, "Calls")
-Rel(reveal, board, "Reads/mutates")
-Rel(board, cell, "Contains")
-Rel(mine_placer, board, "Populates")
-Rel(parser, game, "Passes command")
-Rel(game, renderer, "Passes board snapshot")
-
-@enduml
-```
 
 ### Component Responsibilities
 

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -6,81 +6,22 @@ Three key scenarios are documented below.
 
 ## 6.1 Scenario: Reveal a Cell
 
+![Sequence Diagram - Reveal Cell](diagrams/seq-reveal-cell.svg)
+
 Diagram source: `docs/architecture/diagrams/seq-reveal-cell.puml`
-
-```plantuml
-@startuml seq-reveal-cell
-participant Player
-participant CLI
-participant Game
-participant Board
-
-Player -> CLI : "r 2 3"
-CLI -> CLI : InputParser.parse("r 2 3")
-CLI -> Game : reveal(row=2, col=3)
-Game -> Board : reveal(2, 3)
-alt cell is mine
-  Board --> Game : MINE_HIT
-  Game --> CLI : game_over(loss)
-  CLI --> Player : "BOOM! You hit a mine."
-else cell is empty (no adjacent mines)
-  Board -> Board : flood_fill(2, 3)
-  Board --> Game : OK
-  Game -> Game : check_win()
-  Game --> CLI : board_state
-  CLI --> Player : rendered board
-else cell has adjacent mines
-  Board --> Game : OK
-  Game -> Game : check_win()
-  Game --> CLI : board_state
-  CLI --> Player : rendered board
-end
-@enduml
-```
 
 ---
 
 ## 6.2 Scenario: Flag a Cell
 
+![Sequence Diagram - Flag Cell](diagrams/seq-flag-cell.svg)
+
 Diagram source: `docs/architecture/diagrams/seq-flag-cell.puml`
-
-```plantuml
-@startuml seq-flag-cell
-participant Player
-participant CLI
-participant Game
-participant Board
-
-Player -> CLI : "f 1 4"
-CLI -> CLI : InputParser.parse("f 1 4")
-CLI -> Game : flag(row=1, col=4)
-Game -> Board : toggle_flag(1, 4)
-Board --> Game : OK
-Game --> CLI : board_state
-CLI --> Player : rendered board
-@enduml
-```
 
 ---
 
 ## 6.3 Scenario: Win Condition
 
+![Sequence Diagram - Win Condition](diagrams/seq-win.svg)
+
 Diagram source: `docs/architecture/diagrams/seq-win.puml`
-
-```plantuml
-@startuml seq-win
-participant Player
-participant CLI
-participant Game
-participant Board
-
-Player -> CLI : "r 3 3"
-CLI -> Game : reveal(row=3, col=3)
-Game -> Board : reveal(3, 3)
-Board --> Game : OK
-Game -> Game : check_win()
-note right: all safe cells revealed?
-Game --> CLI : game_over(win)
-CLI --> Player : "You win!"
-@enduml
-```

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -6,20 +6,9 @@ Minesweeper is a single-process CLI application. There is no server, container i
 
 ## 7.2 Deployment Diagram (C4 Level)
 
+![Deployment Diagram](diagrams/deployment.svg)
+
 Diagram source: `docs/architecture/diagrams/deployment.puml`
-
-```plantuml
-@startuml deployment
-!include c4-lib/C4_Deployment.puml
-
-Deployment_Node(machine, "Developer Machine", "Any OS with Python 3.10+") {
-  Deployment_Node(runtime, "Python Interpreter", "CPython 3.10+") {
-    Container(app, "Minesweeper", "Python", "cli.py entry point; all modules loaded in-process")
-  }
-}
-
-@enduml
-```
 
 ## 7.3 How to Run
 


### PR DESCRIPTION
Closes #29

## Changes
- Replace embedded ```plantuml``` blocks with `![...](diagrams/*.svg)` image references in:
  - `03-context-and-scope.md`
  - `05-building-block-view.md`
  - `06-runtime-view.md`
  - `07-deployment-view.md`

## Testing
- [x] Tested locally
- [x] All checks pass